### PR TITLE
Correct includes value in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=Supports SPI protocol where applicable. Also offers scrolling capabili
 category=Display
 url=https://github.com/brigosx/SevenSeg4D
 architectures=avr
-includes=SPI.h
+includes=SevenSeg4D.h


### PR DESCRIPTION
The `includes` field in library.properties is used to specify which `#include` directives should be added to the sketch via **Sketch > Include Library > SevenSeg4D**. This field should specify the primary header file(s) of the library.

All Arduino IDE versions that support the `includes` field do not require `#include` directives in the sketch for dependencies of libraries so there is no point in having SPI.h in the includes field.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format